### PR TITLE
Always specify default sun https handler

### DIFF
--- a/src/main/java/com/coinbase/api/CoinbaseImpl.java
+++ b/src/main/java/com/coinbase/api/CoinbaseImpl.java
@@ -86,19 +86,14 @@ class CoinbaseImpl implements Coinbase {
     CoinbaseImpl(CoinbaseBuilder builder) {
 
         try {
-            String coinbaseBaseUrl = "https://coinbase.com/api/v1/";
-            if (builder.useSunHttpHandler) {
-                // An application server may decide to provide its own http handler. We can 
-                // force the standard http handler by explicitly passing it in. By default 
-                // Weblogic likes to do this. This causes an issue when calling 
-                // URL.openConnection() because the Weblogic handler returns 
-                // SOAPHttpsURLConnection which is not the expected HttpsURLConnection. 
-                // An alternate solution is to force Weblogic in its entirety to use the standard 
-                // http handler with the -DUseSunHttpHandler=true argument.
-                _baseUrl = new URL(null, coinbaseBaseUrl, new sun.net.www.protocol.https.Handler());
-            } else {
-                _baseUrl = new URL(coinbaseBaseUrl);
-            }
+            // This class expects URL.openConnection() to return an instance of
+            // javax.net.ssl.HttpsURLConnection. If another https handler had already
+            // been resolved, openConnection() can return other implementations.
+            // One instance this is a problem is with Weblogic. By default Weblogic
+            // will return weblogic.net.http.SOAPHttpsURLConnection which is not
+            // an instance of HttpsUrlConnection. To resolve, specify the default
+            // sun https handler.
+            _baseUrl = new URL(null, "https://coinbase.com/api/v1/", new sun.net.www.protocol.https.Handler());
         } catch (Exception ex) {
             throw new RuntimeException(ex);
         }


### PR DESCRIPTION
Issue when using this library in Weblogic is that Weblogic it provides its own https handler implementation. Thus line 915 (of the original source) fails when it attempts to cast the Weblogic URLConnection (SOAPHttpsURLConnection) to the default sun (HttpsURLConnection).

Solution here was to create the _baseUrl specifying the default https handler.

For more info about URL.openConnection() returning alternate implementations, view the javadoc: http://docs.oracle.com/javase/7/docs/api/java/net/URL.html
