### PR TITLE
Upgrade to Retrofit2/Okhttp3

### DIFF
--- a/coinbase-java/build.gradle
+++ b/coinbase-java/build.gradle
@@ -11,7 +11,7 @@ buildscript {
 }
 
 def packageName = 'coinbase-java'
-def packageVersion = '2.0.0-49'
+def packageVersion = '2.1.0-50'
 def packageDescription = 'Coinbase Android SDK'
 group = 'com.coinbase'
 version = packageVersion

--- a/coinbase-java/build.gradle
+++ b/coinbase-java/build.gradle
@@ -135,8 +135,8 @@ bintray {
 dependencies {
     compile 'com.google.code.gson:gson:2.5'
     compile 'org.glassfish:javax.annotation:10.0-b28'
-    compile 'com.squareup.retrofit:retrofit:2.0.0-beta2'
-    compile 'com.squareup.retrofit:converter-gson:2.0.0-beta2'
+    compile 'com.squareup.retrofit2:retrofit:2.1.0'
+    compile 'com.squareup.retrofit2:converter-gson:2.1.0'
     compile 'org.joda:joda-money:0.11'
     compile 'joda-time:joda-time:2.3'
     compile 'net.sf.opencsv:opencsv:2.0'

--- a/coinbase-java/src/main/java/com/coinbase/ApiInterface.java
+++ b/coinbase-java/src/main/java/com/coinbase/ApiInterface.java
@@ -18,15 +18,15 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import retrofit.Call;
-import retrofit.http.Body;
-import retrofit.http.DELETE;
-import retrofit.http.GET;
-import retrofit.http.POST;
-import retrofit.http.PUT;
-import retrofit.http.Path;
-import retrofit.http.Query;
-import retrofit.http.QueryMap;
+import retrofit2.Call;
+import retrofit2.http.Body;
+import retrofit2.http.DELETE;
+import retrofit2.http.GET;
+import retrofit2.http.POST;
+import retrofit2.http.PUT;
+import retrofit2.http.Path;
+import retrofit2.http.Query;
+import retrofit2.http.QueryMap;
 
 public interface ApiInterface {
     @POST(ApiConstants.TOKEN)


### PR DESCRIPTION
Note: Retrofit2 no longer passes a Retrofit instance into onResponse.  To get around this, we introduce a new interface
    CallbackWithRetrofit that will provide the instance of Retrofit to your application so you can call
    responseBodyConverter.