### PR TITLE
Remove sandbox from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,8 +268,6 @@ newUser.getEmail(); // "newuser@example.com"
 
 ### Verifying merchant callbacks
 
-Note: Only production callbacks can be verified. Callbacks issued by the sandbox will always return false below.
-
 ```java
 String raw_http_post_body = ...;
 String signature_header   = ...;


### PR DESCRIPTION
The README contained the only reference to the sandbox.