### PR TITLE
Add UK Payment Method Type

### DIFF
--- a/coinbase-java/build.gradle
+++ b/coinbase-java/build.gradle
@@ -12,7 +12,7 @@ buildscript {
 }
 
 def packageName = 'coinbase-java'
-def packageVersion = '2.2.0-131'
+def packageVersion = '2.2.0-132'
 def packageDescription = 'Coinbase Android SDK'
 group = 'com.coinbase'
 version = packageVersion

--- a/coinbase-java/src/main/java/com/coinbase/v2/models/paymentMethods/Data.java
+++ b/coinbase-java/src/main/java/com/coinbase/v2/models/paymentMethods/Data.java
@@ -35,6 +35,8 @@ public class Data {
         BANK_WIRE(),
         @SerializedName("paypal_account")
         PAYPAL_ACCOUNT(),
+        @SerializedName("uk_bank_account")
+        UK_BANK_ACCOUNT,
         UNKNOWN();
 
         @Override


### PR DESCRIPTION
See title.

**Testing Done**

None. This doesn't build with Gradle or Maven.

```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 1.473 s
[INFO] Finished at: 2018-07-25T14:34:10-07:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.1:compile (default-compile) on project coinbase-java: Compilation failure: Compilation failure:
[ERROR] bootstrap class path not set in conjunction with -source 1.6
[ERROR] /Users/warrensmith/Documents/GitHub/coinbase-java/coinbase-java/src/main/java/com/coinbase/v2/models/errors/Errors.java:[15,51] error: diamond operator is not supported in -source 1.6
[ERROR]   (use -source 7 or higher to enable diamond operator)
[ERROR] /Users/warrensmith/Documents/GitHub/coinbase-java/coinbase-java/src/main/java/com/coinbase/v2/models/transfers/TransferError.java:[16,51] error: diamond operator is not supported in -source 1.6
[ERROR]   (use -source 7 or higher to enable diamond operator)
[ERROR] /Users/warrensmith/Documents/GitHub/coinbase-java/coinbase-java/src/main/java/com/coinbase/cache/OkHttpInMemoryLruCache.java:[31,67] error: diamond operator is not supported in -source 1.6
[ERROR]   (use -source 7 or higher to enable diamond operator)
[ERROR] /Users/warrensmith/Documents/GitHub/coinbase-java/coinbase-java/src/main/java/com/coinbase/cache/OkHttpInMemoryLruCache.java:[48,23] error: lambda expressions are not supported in -source 1.6
[ERROR]   (use -source 8 or higher to enable lambda expressions)
[ERROR] /Users/warrensmith/Documents/GitHub/coinbase-java/coinbase-java/src/main/java/com/coinbase/Coinbase.java:[146,101] error: diamond operator is not supported in -source 1.6
[ERROR]   (use -source 7 or higher to enable diamond operator)
[ERROR] /Users/warrensmith/Documents/GitHub/coinbase-java/coinbase-java/src/main/java/com/coinbase/Coinbase.java:[1704,21] error: lambda expressions are not supported in -source 1.6
[ERROR] -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
```