### PR TITLE
Add support for increased price precision for transfers

### DIFF
--- a/coinbase-java/build.gradle
+++ b/coinbase-java/build.gradle
@@ -12,7 +12,7 @@ buildscript {
 }
 
 def packageName = 'coinbase-java'
-def packageVersion = '2.2.0-137'
+def packageVersion = '2.2.0-138'
 def packageDescription = 'Coinbase Android SDK'
 group = 'com.coinbase'
 version = packageVersion

--- a/coinbase-java/src/main/java/com/coinbase/v2/models/transfers/Amount.java
+++ b/coinbase-java/src/main/java/com/coinbase/v2/models/transfers/Amount.java
@@ -15,6 +15,9 @@ public class Amount {
     @SerializedName("currency")
     @Expose
     private String currency;
+    @SerializedName("scale")
+    @Expose
+    private Integer scale;
 
     /**
      * 
@@ -52,4 +55,21 @@ public class Amount {
         this.currency = currency;
     }
 
+    /**
+     * 
+     * @return
+     *     The scale
+     */
+    public Integer getScale() {
+        return scale;
+    }
+
+    /**
+     * 
+     * @param scale
+     *     The scale
+     */
+    public void setScale(Integer scale) {
+        this.scale = scale;
+    }
 }

--- a/coinbase-java/src/main/java/com/coinbase/v2/models/transfers/Data.java
+++ b/coinbase-java/src/main/java/com/coinbase/v2/models/transfers/Data.java
@@ -72,6 +72,9 @@ public class Data {
     @SerializedName("hold_days")
     @Expose
     private Integer holdDays;
+    @SerializedName("unit_price")
+    @Expose
+    private Amount unitPrice;
 
     /**
      * 
@@ -447,5 +450,23 @@ public class Data {
      */
     public void setHoldDays(Integer holdDays) {
         this.holdDays = holdDays;
+    }
+
+    /**
+     * 
+     * @return
+     *     The unit price
+     */
+    public Amount getUnitPrice() {
+        return unitPrice;
+    }
+
+    /**
+     * 
+     * @param unitPrice
+     *     The unit price
+     */
+    public void setUnitPrice(Amount unitPrice) {
+        this.unitPrice = unitPrice;
     }
 }


### PR DESCRIPTION
Added a `scale` field to the `Amount` model as well as `unit_scale` to the `Data` object for transfers. 